### PR TITLE
Tar format support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <artifactId>jobcacher</artifactId>
     <packaging>hpi</packaging>
-    <version>1.1-BETA-4</version>
+    <version>1.1-BETA-5</version>
     <name>Jenkins Job Cacher plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Job+Cacher+Plugin</url>
     <description>Caches files on executors per job and reseeds executors on subsequent builds</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <artifactId>jobcacher</artifactId>
     <packaging>hpi</packaging>
-    <version>1.1-BETA-5</version>
+    <version>1.1-BETA-6</version>
     <name>Jenkins Job Cacher plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Job+Cacher+Plugin</url>
     <description>Caches files on executors per job and reseeds executors on subsequent builds</description>

--- a/src/main/java/jenkins/plugins/itemstorage/StorageFormat.java
+++ b/src/main/java/jenkins/plugins/itemstorage/StorageFormat.java
@@ -11,6 +11,13 @@ public enum StorageFormat {
 
     /**
      * Cache is stored as a single ZIP file, archived before upload storing and unarchived after download.
+     * NOTE: Symlinks archive/unarchive support isn't implemented for this format.
      */
-    ZIP
+    ZIP,
+
+    /**
+     * Cache is stored as a single TAR file, archived before upload storing and unarchived after download.
+     * NOTE: This format preserves and restores symlinks.
+     */
+    TAR
 }

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3UploadAllCallable.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3UploadAllCallable.java
@@ -138,17 +138,28 @@ public class S3UploadAllCallable extends S3BaseUploadCallable<Integer> {
     }
 
     private int uploadAsArchive(TransferManager transferManager, File base, StorageFormat format) throws IOException, InterruptedException {
+
         File archive = File.createTempFile("upload", "archive");
+        String archiveExt;
         try (OutputStream outputStream = new FilePath(archive).write()) {
             FilePath filePath = new FilePath(base);
             switch (format) {
-                case ZIP: filePath.zip(outputStream, scanner); break;
-                case TAR: filePath.tar(outputStream, scanner); break;
+                case ZIP:
+                    filePath.zip(outputStream, scanner);
+                    archiveExt = "zip";
+                    break;
+                case TAR:
+                    filePath.tar(outputStream, scanner);
+                    archiveExt = "tar";
+                    break;
+                default:
+                    throw new IllegalStateException("Unsupported archive format: " + format);
             }
         }
 
         Uploads uploads = new Uploads();
-        String s3key = pathPrefix + "/archive.zip";
+
+        String s3key = pathPrefix + "/archive." + archiveExt;
         ObjectMetadata metadata = buildMetadata(archive);
         Destination destination = new Destination(bucketName, s3key);
 

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/help-storageFormat.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/help-storageFormat.html
@@ -24,5 +24,6 @@
 
 <div>
     Archive storage format. Either DIRECTORY to upload every cached item individually
-    or ZIP/TAR to archive whole cache into a single file and upload into archive.zip.
+    or ZIP/TAR to archive whole cache into a single file and upload into archive.zip/archive.tar.
+    NOTE: TAR format preserves and restores relative symlinks.
 </div>

--- a/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/help-storageFormat.html
+++ b/src/main/resources/jenkins/plugins/itemstorage/s3/S3ItemStorage/help-storageFormat.html
@@ -24,5 +24,5 @@
 
 <div>
     Archive storage format. Either DIRECTORY to upload every cached item individually
-    or ZIP to zip whole cache into a single file and upload into archive.zip.
+    or ZIP/TAR to archive whole cache into a single file and upload into archive.zip.
 </div>


### PR DESCRIPTION
# Overview
There is no support for symlinks in zip utils at the moment. Having tar format as alternative resolves this problem, e.g.: nodejs projects, which has relative symlinks in "node_modules/.bin" by default.